### PR TITLE
Parse arguments in the tests entrypoint

### DIFF
--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,10 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-mkdir -p /dev/net
-mknod /dev/net/tun c 10 200
+# Parse arguments
+args=("$@")
+while [[ $# -gt 0 ]]; do case $1 in
+    --interface)
+    iface=$2
+    shift
+    ;;
+esac; shift; done
 
-wireguard-go wgoverlay
+# Create tun device if necessary
+if [ ! -e /dev/net/tun ]; then
+    mkdir -p /dev/net
+    mknod /dev/net/tun c 10 200
+fi
 
-/app/wesher --log-level debug --cluster-key 'ILICZ3yBMCGAWNIq5Pn0bewBVimW3Q2yRVJ/Be+b1Uc=' "$@"
+wireguard-go ${iface:-wgoverlay}
+/app/wesher --log-level debug --cluster-key 'ILICZ3yBMCGAWNIq5Pn0bewBVimW3Q2yRVJ/Be+b1Uc=' "${args[@]}"


### PR DESCRIPTION
Add an argument parsing routine to the tests entrypoint, and use it to parse the interface name, passed to wireguard-go.

This is cherry-picked out of #44 .