### PR TITLE
WIP: Add NAT support through the use of /advertise(Addr|Port)/

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -30,7 +30,7 @@ type Cluster struct {
 
 // New is used to create a new Cluster instance
 // The returned instance is ready to be updated with the local node settings then joined
-func New(name string, init bool, clusterKey []byte, bindAddr string, bindPort int, useIPAsName bool) (*Cluster, error) {
+func New(name string, init bool, clusterKey []byte, bindAddr string, bindPort int, advertiseAddr string, advertisePort int, useIPAsName bool) (*Cluster, error) {
 	state := &state{}
 	if !init {
 		loadState(state, name)
@@ -46,7 +46,8 @@ func New(name string, init bool, clusterKey []byte, bindAddr string, bindPort in
 	mlConfig.SecretKey = clusterKey
 	mlConfig.BindAddr = bindAddr
 	mlConfig.BindPort = bindPort
-	mlConfig.AdvertisePort = bindPort
+	mlConfig.AdvertiseAddr = advertiseAddr
+	mlConfig.AdvertisePort = advertisePort
 	if useIPAsName && bindAddr != "0.0.0.0" {
 		mlConfig.Name = bindAddr
 	}

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type config struct {
 	Init          bool     `desc:"whether to explicitly (re)initialize the cluster; any known state from previous runs will be forgotten"`
 	BindAddr      string   `id:"bind-addr" desc:"IP address to bind to for cluster membership traffic (cannot be used with --bind-iface)"`
 	BindIface     string   `id:"bind-iface" desc:"Interface to bind to for cluster membership traffic (cannot be used with --bind-addr)"`
+	AdvertiseAddr string   `id:"advertise-addr" desc:"IP address to advertise to other nodes for NAT traversal"`
 	ClusterPort   int      `id:"cluster-port" desc:"port used for membership gossip traffic (both TCP and UDP); must be the same across cluster" default:"7946"`
 	WireguardPort int      `id:"wireguard-port" desc:"port used for wireguard traffic (UDP); must be the same across cluster" default:"51820"`
 	OverlayNet    *network `id:"overlay-net" desc:"the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision" default:"10.0.0.0/8"`
@@ -74,6 +75,10 @@ func loadConfig() (*config, error) {
 		} else {
 			config.BindAddr = "0.0.0.0"
 		}
+	}
+
+	if config.AdvertiseAddr == "" {
+		config.AdvertiseAddr = config.BindAddr
 	}
 
 	return &config, nil

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	logrus.SetLevel(logLevel)
 
 	// Create the wireguard and cluster configuration
-	cluster, err := cluster.New(config.Interface, config.Init, config.ClusterKey, config.BindAddr, config.ClusterPort, config.UseIPAsName)
+	cluster, err := cluster.New(config.Interface, config.Init, config.ClusterKey, config.BindAddr, config.ClusterPort, config.AdvertiseAddr, config.ClusterPort, config.UseIPAsName)
 	if err != nil {
 		logrus.WithError(err).Fatal("could not create cluster")
 	}


### PR DESCRIPTION
Fixes #8

This could benefit some hypothetical cloud-to-cloud situation that had to be communicated though internet, e.g. interconnect from AWS to GCP without using their overpriced VPN service.

By default the advertise address would be the same as the final bind address, and advertise port is not yet changeable (implied by ClusterPort). The behavior is the same as before if you don't use the advertise address.

This is not yet finished due to missing tests