### PR TITLE
Routed networks, MTU and node change script executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ All options can be passed either as command-line flags or environment variables:
 | `--wireguard-port PORT` | WESHER_WIREGUARD_PORT | port used for wireguard traffic (UDP); must be the same across cluster | `51820` |
 | `--overlay-net ADDR/MASK` | WESHER_OVERLAY_NET | the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision | `10.0.0.0/8` |
 | `--interface DEV` | WESHER_INTERFACE | name of the wireguard interface to create and manage | `wgoverlay` |
+| `--routed-net NETWORK/CIDR` | WESHER_ROUTED_NET | additional network to be routed to the node on which wether runs | |
+| `--mtu MTU` | WESHER_MTU | MTU value for the wireguard interface | `mtu` |
+| `--node-update-script PATH_TO_SCRIPT` | WESHER_NODE_UPDATE_SCRIPT | script to execute everytime there is a node change, this runs as soon as a node joins, updates and/or leaves the cluster. In conjunction with `--routed-net`, which doesn't add routes automatically, this can be used to add routes very flexible depending on each individual system. See utilites/update-node-routes.sh as an example script |  |
 | `--no-etc-hosts` | WESHER_NO_ETC_HOSTS | whether to skip writing hosts entries for each node in mesh | `false` |
 | `--log-level LEVEL` | WESHER_LOG_LEVEL | set the verbosity (one of debug/info/warn/error) | `warn` |
 

--- a/common/node.go
+++ b/common/node.go
@@ -11,6 +11,7 @@ import (
 // nodeMeta holds metadata sent over the cluster
 type nodeMeta struct {
 	OverlayAddr net.IPNet
+	Routes      []net.IPNet
 	PubKey      string
 }
 

--- a/common/routes.go
+++ b/common/routes.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Routes pushes list of local routes to a channel, after filtering using the provided network
+// The full list is pushed after every routing change
+func Routes(filter *net.IPNet) <-chan []net.IPNet {
+	routesc := make(chan []net.IPNet)
+	updatec := make(chan netlink.RouteUpdate)
+	netlink.RouteSubscribe(updatec, make(chan struct{}))
+	go func() {
+		for {
+			<-updatec
+			routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+			if err != nil {
+				continue
+			}
+			result := make([]net.IPNet, 0)
+			for _, route := range routes {
+				if route.Dst != nil && filter.Contains(route.Dst.IP) {
+					result = append(result, *route.Dst)
+				}
+			}
+			routesc <- result
+		}
+	}()
+	return routesc
+}

--- a/config.go
+++ b/config.go
@@ -11,20 +11,21 @@ import (
 )
 
 type config struct {
-	ClusterKey    []byte   `id:"cluster-key" desc:"shared key for cluster membership; must be 32 bytes base64 encoded; will be generated if not provided"`
-	Join          []string `desc:"comma separated list of hostnames or IP addresses to existing cluster members; if not provided, will attempt resuming any known state or otherwise wait for further members."`
-	Init          bool     `desc:"whether to explicitly (re)initialize the cluster; any known state from previous runs will be forgotten"`
-	BindAddr      string   `id:"bind-addr" desc:"IP address to bind to for cluster membership traffic (cannot be used with --bind-iface)"`
-	BindIface     string   `id:"bind-iface" desc:"Interface to bind to for cluster membership traffic (cannot be used with --bind-addr)"`
-	ClusterPort   int      `id:"cluster-port" desc:"port used for membership gossip traffic (both TCP and UDP); must be the same across cluster" default:"7946"`
-	WireguardPort int      `id:"wireguard-port" desc:"port used for wireguard traffic (UDP); must be the same across cluster" default:"51820"`
-	MTU           int      `id:"mtu" desc:"mtu for wireguard interface" default:"1420"`
-	OverlayNet    *network `id:"overlay-net" desc:"the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision" default:"10.0.0.0/8"`
-	RoutedNet     *network `id:"routed-net" desc:"network used to filter routes that nodes are allowed to announce (CIDR format)" default:"0.0.0.0/32"`
-	Interface     string   `desc:"name of the wireguard interface to create and manage" default:"wgoverlay"`
-	NoEtcHosts    bool     `id:"no-etc-hosts" desc:"disable writing of entries to /etc/hosts"`
-	LogLevel      string   `id:"log-level" desc:"set the verbosity (debug/info/warn/error)" default:"warn"`
-	Version       bool     `desc:"display current version and exit"`
+	ClusterKey       []byte   `id:"cluster-key" desc:"shared key for cluster membership; must be 32 bytes base64 encoded; will be generated if not provided"`
+	Join             []string `desc:"comma separated list of hostnames or IP addresses to existing cluster members; if not provided, will attempt resuming any known state or otherwise wait for further members."`
+	Init             bool     `desc:"whether to explicitly (re)initialize the cluster; any known state from previous runs will be forgotten"`
+	BindAddr         string   `id:"bind-addr" desc:"IP address to bind to for cluster membership traffic (cannot be used with --bind-iface)"`
+	BindIface        string   `id:"bind-iface" desc:"Interface to bind to for cluster membership traffic (cannot be used with --bind-addr)"`
+	ClusterPort      int      `id:"cluster-port" desc:"port used for membership gossip traffic (both TCP and UDP); must be the same across cluster" default:"7946"`
+	WireguardPort    int      `id:"wireguard-port" desc:"port used for wireguard traffic (UDP); must be the same across cluster" default:"51820"`
+	MTU              int      `id:"mtu" desc:"mtu for wireguard interface" default:"1420"`
+	OverlayNet       *network `id:"overlay-net" desc:"the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision" default:"10.0.0.0/8"`
+	RoutedNet        *network `id:"routed-net" desc:"network used to filter routes that nodes are allowed to announce (CIDR format)" default:"0.0.0.0/32"`
+	Interface        string   `desc:"name of the wireguard interface to create and manage" default:"wgoverlay"`
+	NoEtcHosts       bool     `id:"no-etc-hosts" desc:"disable writing of entries to /etc/hosts"`
+	LogLevel         string   `id:"log-level" desc:"set the verbosity (debug/info/warn/error)" default:"warn"`
+	Version          bool     `desc:"display current version and exit"`
+	NodeUpdateScript string   `id:"node-update-script" desc:"path to script which is executed everytime the service receives an update for a node"`
 
 	// for easier local testing; will break etchosts entry
 	UseIPAsName bool `id:"ip-as-name" default:"false" opts:"hidden"`

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type config struct {
 	ClusterPort   int      `id:"cluster-port" desc:"port used for membership gossip traffic (both TCP and UDP); must be the same across cluster" default:"7946"`
 	WireguardPort int      `id:"wireguard-port" desc:"port used for wireguard traffic (UDP); must be the same across cluster" default:"51820"`
 	OverlayNet    *network `id:"overlay-net" desc:"the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision" default:"10.0.0.0/8"`
+	RoutedNet     *network `id:"routed-net" desc:"network used to filter routes that nodes are allowed to announce (CIDR format)" default:"0.0.0.0/32"`
 	Interface     string   `desc:"name of the wireguard interface to create and manage" default:"wgoverlay"`
 	NoEtcHosts    bool     `id:"no-etc-hosts" desc:"disable writing of entries to /etc/hosts"`
 	LogLevel      string   `id:"log-level" desc:"set the verbosity (debug/info/warn/error)" default:"warn"`

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type config struct {
 	BindIface     string   `id:"bind-iface" desc:"Interface to bind to for cluster membership traffic (cannot be used with --bind-addr)"`
 	ClusterPort   int      `id:"cluster-port" desc:"port used for membership gossip traffic (both TCP and UDP); must be the same across cluster" default:"7946"`
 	WireguardPort int      `id:"wireguard-port" desc:"port used for wireguard traffic (UDP); must be the same across cluster" default:"51820"`
+	MTU           int      `id:"mtu" desc:"mtu for wireguard interface" default:"1420"`
 	OverlayNet    *network `id:"overlay-net" desc:"the network in which to allocate addresses for the overlay mesh network (CIDR format); smaller networks increase the chance of IP collision" default:"10.0.0.0/8"`
 	RoutedNet     *network `id:"routed-net" desc:"network used to filter routes that nodes are allowed to announce (CIDR format)" default:"0.0.0.0/32"`
 	Interface     string   `desc:"name of the wireguard interface to create and manage" default:"wgoverlay"`

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("could not create cluster")
 	}
-	wgstate, localNode, err := wg.New(config.Interface, config.WireguardPort, (*net.IPNet)(config.OverlayNet), cluster.LocalName)
+	wgstate, localNode, err := wg.New(config.Interface, config.WireguardPort, config.MTU, (*net.IPNet)(config.OverlayNet), cluster.LocalName)
 	if err != nil {
 		logrus.WithError(err).Fatal("could not instantiate wireguard controller")
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -91,6 +92,18 @@ func main() {
 			if !config.NoEtcHosts {
 				if err := hostsFile.WriteEntries(hosts); err != nil {
 					logrus.WithError(err).Error("could not write hosts entries")
+				}
+			}
+			if len(config.NodeUpdateScript) > 0 {
+				updateScript, _ := exec.LookPath(config.NodeUpdateScript)
+				cmd := &exec.Cmd{
+					Path:   updateScript,
+					Args:   []string{updateScript, config.Interface},
+					Stdout: os.Stdout,
+					Stderr: os.Stderr,
+				}
+				if err := cmd.Run(); err != nil {
+					logrus.Errorf("error while executing node-update-script: %s", err)
 				}
 			}
 		case routes := <-routesc:

--- a/main.go
+++ b/main.go
@@ -75,11 +75,12 @@ func main() {
 			hosts := make(map[string][]string, len(rawNodes))
 			logrus.Info("cluster members:\n")
 			for _, node := range rawNodes {
+
 				if err := node.DecodeMeta(); err != nil {
 					logrus.Warnf("\t addr: %s, could not decode metadata", node.Addr)
 					continue
 				}
-				logrus.Infof("\taddr: %s, overlay: %s, pubkey: %s", node.Addr, node.OverlayAddr, node.PubKey)
+				logrus.Infof("\taddr: %s, overlay: %s, pubkey: %s, net: %s, routes: %s", node.Addr, node.OverlayAddr, node.PubKey, node.Routes)
 				nodes = append(nodes, node)
 				hosts[node.OverlayAddr.IP.String()] = []string{node.Name}
 			}

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 					Stderr: os.Stderr,
 				}
 				if err := cmd.Run(); err != nil {
-					logrus.Errorf("error while executing node-update-script: %s", err)
+					logrus.Errorf("error while executing node-update-script %s: %s", config.NodeUpdateScript, err)
 				}
 			}
 		case routes := <-routesc:

--- a/utilities/update-node-routes.sh
+++ b/utilities/update-node-routes.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DATE=$(date)
+INTERFACE="${1}"
+ROUTES=$(ip route show)
+WG_ALLOWED_IPS=($(wg show ${1} |grep 'allowed ips' |sed 's/allowed ips://g' |sed 's/^[[:space:]]*//g' |sed 's/,//g'))
+
+for NETWORK in "${WG_ALLOWED_IPS[@]}"
+do
+	CLEANED_NETWORK=$(echo "${NETWORK}" |sed 's/\/32//g')
+
+	NETWORK_ALREADY_EXISTS=$(echo "${ROUTES}" |grep "${CLEANED_NETWORK}")
+	if [ -z "${NETWORK_ALREADY_EXISTS}" ]; then
+		echo "${DATE}: network ${NETWORK} is missing, adding route for ${INTERFACE}"
+		ip route add ${NETWORK} dev ${INTERFACE}
+	fi
+done

--- a/utilities/update-node-routes.sh
+++ b/utilities/update-node-routes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DATE=$(date)
 INTERFACE="${1}"


### PR DESCRIPTION
We were looking for a solution like that to replace our internal, very configuration heavy, tooling and found Wesher which is a great concept in our opinion. 

Since we needed a bit more flexibility around the networks (AllowedIps) part we added the following functionality and would love to see it merged:

- Merging the change from https://github.com/kaiyou/wesher which adds the possibility to add a nodes network to the `AllowedIps` configuration of the Wireguard interface: `--routed-nets`
- Added the possibility to configure MTU instead of hard-coded 1420: `--mtu`
- Added the possibility to execute a custom program (e.g. shell script) everytime a node change happens (NodeJoin, NodeLeave, NodeUpdate): `--node-update-script`
- Added an example script of how to use `--routed-nets` together with `--node-update-script` so that all nodes of the cluster adding a corresponding route based on `wg show $INTERFACE`: utilities/update-node-routes.sh